### PR TITLE
Flaky tests

### DIFF
--- a/test/riffed/client_test.exs
+++ b/test/riffed/client_test.exs
@@ -166,7 +166,7 @@ defmodule ClientTest do
   test_with_mock "it should use callbacks to convert things to erlang", :thrift_client,
   [call: &EchoServer.call/3] do
 
-    response = Client.setLoudUser(Models.LoudUser.new(firstName: "STINKY", lastName: "STINKMAN"))
+    Client.setLoudUser(Models.LoudUser.new(firstName: "STINKY", lastName: "STINKMAN"))
     {call_name, [user_tuple]} = EchoServer.last_call
 
     assert call_name == :setLoudUser

--- a/test/riffed/integration_test.exs
+++ b/test/riffed/integration_test.exs
@@ -105,8 +105,14 @@ defmodule IntegrationTest do
   end
 
   setup do
-    IntegServer.start_link
-    ServerWithErrorHandler.start_link
+    {:ok, integ_server_pid} = IntegServer.start_link
+    {:ok, error_server_pid} = ServerWithErrorHandler.start_link
+
+    on_exit fn ->
+      Utils.ensure_pid_stopped(integ_server_pid)
+      Utils.ensure_pid_stopped(error_server_pid)
+    end
+
     :ok
   end
 

--- a/test/riffed/shared_struct_test.exs
+++ b/test/riffed/shared_struct_test.exs
@@ -45,7 +45,7 @@ defmodule SharingTests do
                                        sendUpdates: false} = account.preferences
     inactive_status = Status.Status.inactive
 
-    assert inactive_status = elixirized.status
+    assert ^inactive_status = elixirized.status
   end
 
   test "it should be able to convert elixir structs into erlang records" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,32 @@
-ExUnit.start()
+ExUnit.start(max_cases: 1)
+
+defmodule Utils do
+
+  def ensure_pid_stopped(server_pid) do
+    Process.exit(server_pid, :normal)
+    wait_to_die(server_pid)
+  end
+
+  def ensure_agent_stopped(module_name) do
+    try do
+      case Process.whereis(module_name) do
+        pid when is_pid(pid) ->
+          Agent.stop(pid)
+          Utils.wait_to_die(pid)
+        _ ->
+          nil
+      end
+    catch :exit, _ ->
+        nil
+    end
+  end
+
+  def wait_to_die(pid) do
+    if Process.alive?(pid) do
+      wait_to_die(pid)
+    end
+  end
+end
 
 defmodule EchoServer do
   use GenServer


### PR DESCRIPTION
The tests were dying because we weren't waiting on the agents to die before starting the next test. This change ensures that we wait on them. 

@jparise @jyang15 