### PR TITLE
Fix upgrade excoveralls to 0.4.5

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,7 @@ defmodule Riffed.Mixfile do
         {:exlager, github: "khia/exlager"},
         {:earmark, "~> 0.1", only: :dev},
         {:ex_doc, "~> 0.8", only: :dev},
-        {:excoveralls, github: "parroty/excoveralls", tag: "v0.4.3", override: true, only: :test}
+        {:excoveralls, github: "parroty/excoveralls", tag: "v0.4.5", override: true, only: :test}
     ]
   end
 


### PR DESCRIPTION
Upgrade all elixir project to use same version as in elixir-thrift:
reference
https://github.com/pinterest/elixir-thrift/commit/12407035ff5fe480ba957c1379d4478ef1099fb5