### PR TITLE
bumped dep version in tutorial and getting started guide

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -6,7 +6,7 @@ We'll assume you already have a Mix project to work with called `rift_tutorial`.
 
 ```elixir
 def deps do
-  [{:riffed, github: "pinterest/riffed", tag: "0.1", submodules: true}]
+  [{:riffed, github: "pinterest/riffed", tag: "1.0.0", submodules: true}]
 end
 ```
 

--- a/examples/tutorial/mix.exs
+++ b/examples/tutorial/mix.exs
@@ -31,7 +31,7 @@ defmodule RiffedTutorial.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:riffed, github: "pinterest/riffed", tag: "0.1", submodules: true}
+      {:riffed, github: "pinterest/riffed", tag: "1.0.0", submodules: true}
     ]
   end
 end

--- a/examples/tutorial/mix.lock
+++ b/examples/tutorial/mix.lock
@@ -1,1 +1,7 @@
-%{}
+%{"exlager": {:git, "https://github.com/khia/exlager.git", "abb13435a540731b8b9c5f649f4d94f11a27c1f7", []},
+  "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "212299233c7e7eb63a97be2777e1c05ebaa58dbe", [tag: "0.1.8"]},
+  "lager": {:git, "https://github.com/basho/lager.git", "b2cb2735713e3021e0761623ff595d53a545438e", []},
+  "meck": {:hex, :meck, "0.8.4"},
+  "mock": {:git, "https://github.com/jjh42/mock.git", "cac37bc0567d8f61e542dbe29944844261888b3a", []},
+  "riffed": {:git, "https://github.com/pinterest/riffed.git", "ca083d52d4ecfad822432da3925f644bc748f260", [tag: "1.0.0", submodules: true]},
+  "thrift": {:git, "https://github.com/pinterest/elixir-thrift.git", "9c3871cc9568eaf23c701ae11dece7bb5790b8ab", [tag: "1.0.0", submodules: true]}}


### PR DESCRIPTION
Hi there!

Just noticed a small issue while going through the tutorial. `mix deps.get` fails because the tag provided in the getting started guide and in the example project does not exist.

The mix.lock file updated too; I haven't contributed to an elixir project before, so I'm not sure if that's OK or not to accept.
