### PR TITLE
Simple client

### DIFF
--- a/examples/tutorial/lib/riffed_tutorial/simple_client.ex
+++ b/examples/tutorial/lib/riffed_tutorial/simple_client.ex
@@ -1,0 +1,28 @@
+defmodule RiffedTutorial.SimpleClient do
+  use Riffed.SimpleClient,
+    auto_import_structs: false,
+    structs: RiffedTutorial.Models,
+    client: [
+      :thrift_reconnecting_client,
+      'localhost',          # Host
+      2112,                 # Port
+      :tutorial_thrift,     # ThriftSvc
+      [                     # ThriftOpts
+        framed: true,
+        recv_timeout: 3_000,
+      ],
+      100,                  # ReconnMin
+      3_000,                # ReconnMax
+    ],
+    retry_delays: {100, 300, 1_000},
+    service: :tutorial_thrift,
+    import: [
+      :registerUser,
+      :getUser,
+      :getState,
+      :setState,
+    ]
+
+  enumerize_function setState(_, UserState)
+  enumerize_function getState(_), returns: UserState
+end

--- a/lib/riffed/simple_client.ex
+++ b/lib/riffed/simple_client.ex
@@ -8,7 +8,7 @@ defmodule Riffed.SimpleClient do
   Riffed's wrapper does, dutifully converting between Elixir and thrift for you.
 
       defmodule Client do
-        use Riffed.Client,
+        use Riffed.SimpleClient,
           structs: Models,
           client: [
             :thrift_reconnecting_client,

--- a/lib/riffed/simple_client.ex
+++ b/lib/riffed/simple_client.ex
@@ -188,6 +188,8 @@ defmodule Riffed.SimpleClient do
       when retry_count <= unquote(num_retries) do
         response = unquote(client_module).call(client, call_name, args)
         case response do
+          {:error, :closed} ->
+            retry_delay(client, call_name, args, retry_count)
           {:error, :econnaborted} ->
             retry_delay(client, call_name, args, retry_count)
           {:error, :noconn} ->

--- a/lib/riffed/simple_client.ex
+++ b/lib/riffed/simple_client.ex
@@ -1,0 +1,219 @@
+defmodule Riffed.SimpleClient do
+  @moduledoc ~S"""
+  Provides a simple client wrapper, that can specify underlying module.
+
+  ## Usage
+  The Erlang Thrift client implementation doesn't provide useful Elixir
+  mappings, nor does it gracefully handle socket termination.
+  Riffed's wrapper does, dutifully converting between Elixir and thrift for you.
+
+      defmodule Client do
+        use Riffed.Client,
+          structs: Models,
+          client: [
+            :thrift_reconnecting_client,
+            'localhost',          # Host
+            2112,                 # Port
+            :my_library_thrift,   # ThriftSvc
+            [framed: true],       # ThriftOpts
+            100,                  # ReconnMin
+            3_000,                # ReconnMax
+          ],
+          retry_delays: {100, 300, 1_000},
+          service: :my_library_thrift,
+          import: [
+            :configure,
+            :create,
+            :update,
+            :delete,
+          ]
+
+        defenum UserState do
+          :active -> 1
+          :inactive -> 2
+          :banned -> 3
+        end
+
+        enumerize_struct(User, state: UserState)
+      end
+
+  In the above example, you can see that we've imported the functions
+  `configure`, `create`, `update`, and `delete`.
+  Riffed generates helper functions in the `Client` module
+  that convert to and from Elixir. To use the client, simply invoke:
+
+      Client.start_link
+
+      Client.configure("config", 234)
+      Client.create(Models.user.new(first_name: "Stinky", last_name: "Stinkman")
+      Client.close
+
+  The Elixir bitstrings will be automatically converted to erlang char lists
+  when being sent to the thrift client, and char lists from the client will be
+  automatically converted to bitstrings when returned *by* the thrift client.
+  Riffed looks at your thrift definitions to find out when this should happen,
+  so it's safe.
+  """
+  import Riffed.MacroHelpers
+  import Riffed.ThriftMeta, only: [extract: 2]
+  alias Riffed.ThriftMeta.Meta, as: Meta
+
+  defmacro __using__(opts) do
+    struct_module_name = opts[:structs]
+    client = opts[:client]
+    retry_delays = opts[:retry_delays]
+    thrift_module = opts[:service]
+    functions = opts[:import]
+    auto_import_structs = Keyword.get(opts, :auto_import_structs, true)
+
+    quote do
+      use Riffed.Callbacks
+      use Riffed.Enumeration
+
+      @struct_module unquote(struct_module_name)
+      @client unquote(client)
+      @retry_delays unquote(retry_delays)
+      @thrift_module unquote(thrift_module)
+      @functions unquote(functions)
+      @auto_import_structs unquote(auto_import_structs)
+      @before_compile Riffed.SimpleClient
+    end
+  end
+
+  defp build_client_function(metadata, struct_module, func, overrides) do
+    function_meta = Meta.metadata_for_function(metadata, func)
+    param_meta = function_meta[:params]
+    reply_meta = function_meta[:reply] |> Riffed.Struct.to_riffed_type_spec
+    reply_meta = Riffed.Enumeration.get_overridden_type(
+      func, :return_type, overrides, reply_meta)
+
+    arg_list = build_arg_list(length(param_meta))
+    {:{}, _, list_args} = build_handler_tuple_args(param_meta)
+    casts = build_casts(func, struct_module, param_meta, overrides, :to_erlang)
+
+    quote do
+      def unquote(func)(unquote_splicing(arg_list)) do
+        unquote(func)(__MODULE__, unquote_splicing(arg_list))
+      end
+
+      def unquote(func)(client, unquote_splicing(arg_list)) do
+        unquote_splicing(casts)
+        result = call_thrift(client, unquote(func), unquote(list_args), 0)
+        case result do
+          {:ok, reply} ->
+            {:ok, unquote(struct_module).to_elixir(reply, unquote(reply_meta))}
+          other ->
+            other
+        end
+      end
+    end
+  end
+
+  defp build_client_functions(functions, metadata, struct_module, overrides) do
+    Enum.map(functions, &build_client_function(
+      metadata, struct_module, &1, overrides))
+  end
+
+  defmacro __before_compile__(env) do
+    overrides = Riffed.Enumeration.get_overrides(env.module).functions
+    client = Module.get_attribute(env.module, :client)
+    retry_delays = Module.get_attribute(env.module, :retry_delays)
+    struct_module = Module.get_attribute(env.module, :struct_module)
+    thrift_module = Module.get_attribute(env.module, :thrift_module)
+    functions = Module.get_attribute(env.module, :functions)
+
+    [client_module | client_args] = client
+    metadata = extract(thrift_module, functions)
+    num_retries = retry_delays && tuple_size(retry_delays) || 0
+
+    client_functions = build_client_functions(
+      functions, metadata, struct_module, overrides)
+
+    if Module.get_attribute(env.module, :auto_import_structs) do
+      struct_module = quote do
+        defmodule unquote(struct_module) do
+          use Riffed.Struct, unquote(Meta.structs_to_keyword(metadata))
+          unquote_splicing(Riffed.Callbacks.reconstitute(env.module))
+          unquote_splicing(Riffed.Enumeration.reconstitute(env.module))
+        end
+      end
+    else
+      struct_module = quote do
+      end
+    end
+
+    quote do
+      unquote(struct_module)
+
+      unquote_splicing(client_functions)
+
+      def start_link do
+        case Process.whereis(__MODULE__) do
+          nil ->
+            ret = unquote(client_module).start_link(
+              unquote_splicing(client_args))
+            case ret do
+              {:ok, pid} ->
+                if Process.whereis(unquote(client_module)) == pid do
+                  Process.unregister(unquote(client_module))
+                end
+                Process.register(pid, __MODULE__)
+                {:ok, pid}
+              other ->
+                other
+            end
+          pid ->
+            {:error, {:already_started, pid}}
+        end
+      end
+
+      def start_link(module, args) do
+        apply(module, :start_link, args)
+      end
+
+      def stop do
+        case Process.whereis(__MODULE__) do
+          nil ->
+            :ok
+          pid ->
+            :gen_server.stop(pid)
+        end
+      end
+
+      def stop(pid) do
+        :gen_server.stop(pid)
+      end
+
+      defp call_thrift(client, call_name, args, retry_count)
+      when retry_count <= unquote(num_retries) do
+        response = unquote(client_module).call(client, call_name, args)
+        case response do
+          {:error, :econnaborted} ->
+            retry_delay(client, call_name, args, retry_count)
+          {:error, :noconn} ->
+            retry_delay(client, call_name, args, retry_count)
+          other ->
+            other
+        end
+      end
+
+      defp call_thrift(client, call_name, args, retry_count) do
+        {:error, :retries_exceeded}
+      end
+
+      defp retry_delay(client, call_name, args, retry_count) do
+        delay = get_delay(@retry_delays, retry_count)
+        :timer.sleep(delay)
+        call_thrift(client, call_name, args, retry_count + 1)
+      end
+
+      defp get_delay(nil, _index), do: 0
+      defp get_delay({}, _index), do: 0
+      defp get_delay(_delays, index) when index < 0, do: 0
+      defp get_delay(delays, index)
+      when tuple_size(delays) > index, do: elem(delays, index)
+      defp get_delay(delays, _index), do: elem(delays, tuple_size(delays) - 1)
+
+    end
+  end
+end

--- a/test/riffed/simple_client_test.exs
+++ b/test/riffed/simple_client_test.exs
@@ -1,0 +1,292 @@
+defmodule SimpleClientTest do
+  use ExUnit.Case
+  import Mock
+
+  defmodule SimpleClientEchoServer do
+    use GenServer
+
+    def start_link do
+      GenServer.start_link(__MODULE__, nil, name: __MODULE__)
+    end
+
+    def call(_client, name, args) do
+      GenServer.call(__MODULE__, {name, args})
+    end
+
+    def last_call do
+      GenServer.call(__MODULE__, :get_last_args)
+    end
+
+    def set_args(args) do
+      GenServer.call(__MODULE__, {:set_args, args})
+    end
+
+    def handle_call({:set_args, args}, _parent, _state) do
+      {:reply, args, args}
+    end
+
+    def handle_call(req={_call_name, args}, _parent, _state) do
+      {:reply, {:ok, args}, req}
+    end
+
+    def handle_call(:get_last_args, _parent, state) do
+      {:reply, state, state}
+    end
+  end
+
+  defmodule Client do
+    use Riffed.SimpleClient,
+      structs: SimpleClientModels,
+      client: [
+        :thrift_reconnecting_client,
+        'localhost',          # Host
+        2112,                 # Port
+        :server_thrift,       # ThriftSvc
+        [framed: true],       # ThriftOpts
+        100,                  # ReconnMin
+        3_000,                # ReconnMax
+      ],
+      retry_delays: {100},
+      service: :server_thrift,
+      import: [
+        :config,
+        :setUserState,
+        :dictFun,
+        :dictUserFun,
+        :setUserFun,
+        :getState,
+        :getTranslatedState,
+        :getLoudUser,
+        :setLoudUser,
+        :echoState,
+        :echoActivityStateList,
+        :getUserStates,
+        :getAllStates,
+        :getUsers,
+        :functionWithoutNumberedArgs
+      ]
+
+    defenum ActivityState do
+      :active -> 1
+      :inactive -> 2
+      :banned -> 3
+    end
+
+    enumerize_function getState(ActivityState), returns: ActivityState
+    enumerize_function setUserState(_, ActivityState)
+    enumerize_function getTranslatedState(ActivityState),
+      returns: ActivityState
+    enumerize_function echoState(ActivityState), returns: ActivityState
+    enumerize_function echoActivityStateList({:list, ActivityState}),
+      returns: {:list, ActivityState}
+    enumerize_function getUserStates(_),
+      returns: {:map, {:string, ActivityState}}
+    enumerize_function getAllStates, returns: {:set, ActivityState}
+
+    enumerize_struct User, state: ActivityState
+
+    callback(:after_to_elixir, user=%LoudUser{}) do
+      %SimpleClientModels.LoudUser{
+        user |
+        firstName: String.upcase(user.firstName),
+        lastName: String.upcase(user.lastName)}
+    end
+
+    callback(:after_to_erlang, {:LoudUser, first_name, last_name}) do
+      {:LoudUser, String.downcase(first_name), String.downcase(last_name)}
+    end
+  end
+
+  setup do
+    {:ok, pid} = SimpleClientEchoServer.start_link
+    with_mock :thrift_reconnecting_client, [
+      start_link: fn(_, _, _, _, _, _) -> {:ok, pid} end] do
+      {:ok, ^pid} = Client.start_link(:thrift_reconnecting_client, [
+        'localhost',          # Host
+        2112,                 # Port
+        :server_thrift,       # ThriftSvc
+        [framed: true],       # ThriftOpts
+        100,                  # ReconnMin
+        3_000,                # ReconnMax
+      ])
+    end
+    on_exit fn -> Utils.ensure_pid_stopped(pid) end
+    Process.put(:simple_client_pid, pid)
+    {:ok, pid: pid}
+  end
+
+  def user_struct do
+    SimpleClientModels.User.new(
+      firstName: "Foobie",
+      lastName: "Barson",
+      state: SimpleClientModels.ActivityState.active)
+  end
+
+  def user_tuple do
+    {:User, "Foobie", "Barson", 1}
+  end
+
+  def config_request_struct do
+    SimpleClientModels.ConfigRequest.new(
+      template: "foo/bar",
+      requestCount: 32,
+      user: user_struct)
+  end
+
+  def respond_with(response) do
+    fn(_client, fn_name, args) ->
+      SimpleClientEchoServer.set_args({fn_name, args})
+      {:ok, response}
+    end
+  end
+
+  test "it should convert nested structs into erlang" do
+    converted = SimpleClientModels.to_erlang(
+      config_request_struct, {:struct, {:models, :ConfigRequest}})
+    assert converted == {
+      :ConfigRequest, "foo/bar", 32, {:User, "Foobie", "Barson", 1}}
+  end
+
+  test_with_mock "it should convert structs into their correct types",
+  :thrift_reconnecting_client,
+  [call: respond_with({:ConfigResponse, "foo/bar", 3, 32})] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.config(pid, config_request_struct, 3)
+    assert response == SimpleClientModels.ConfigResponse.new(
+      template: "foo/bar", requestCount: 3, per: 32)
+    assert SimpleClientEchoServer.last_call == {:config, [
+      {:ConfigRequest, "foo/bar", 32, {:User, "Foobie", "Barson", 1}}, 3]}
+  end
+
+  test_with_mock "it should convert structs in dicts",
+  :thrift_reconnecting_client,
+  [call: respond_with(:dict.from_list([{"foobar", user_tuple}]))] do
+    pid = Process.get(:simple_client_pid)
+    dict_arg = Enum.into([{"foobar", user_struct}], HashDict.new)
+    {:ok, response} = Client.dictUserFun(pid, dict_arg)
+    assert response == dict_arg
+    assert SimpleClientEchoServer.last_call == {
+      :dictUserFun, [:dict.from_list([{"foobar", user_tuple}])]}
+  end
+
+  test_with_mock "it should convert structs in sets",
+  :thrift_reconnecting_client,
+  [call: respond_with(:sets.from_list([user_tuple]))] do
+    pid = Process.get(:simple_client_pid)
+    set_arg = Enum.into([user_struct], HashSet.new)
+    {:ok, response} = Client.setUserFun(pid, set_arg)
+    assert response == set_arg
+    {call_name, [set_arg]} = SimpleClientEchoServer.last_call
+    assert call_name == :setUserFun
+    assert set_arg == :sets.from_list([{:User, "Foobie", "Barson", 1}])
+  end
+
+  test_with_mock "it should convert enums in args",
+  :thrift_reconnecting_client,
+  [call: respond_with(3)] do
+    pid = Process.get(:simple_client_pid)
+    user_state = SimpleClientModels.ActivityState.inactive
+    {:ok, response} = Client.getState(pid, user_state)
+    assert response == SimpleClientModels.ActivityState.banned
+    {call_name, [state]} = SimpleClientEchoServer.last_call
+    assert call_name == :getState
+    assert state == SimpleClientModels.ActivityState.inactive.value
+  end
+
+  test_with_mock "it should convert enums returned by client functions",
+  :thrift_reconnecting_client,
+  [call: respond_with(2)] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.getTranslatedState(
+      pid, SimpleClientModels.ActivityState.banned)
+    assert response == SimpleClientModels.ActivityState.inactive
+    assert SimpleClientEchoServer.last_call == {:getTranslatedState, [3]}
+  end
+
+  test_with_mock "it shold convert enums in args and return values",
+  :thrift_reconnecting_client,
+  [call: fn(_client, _name, args) ->
+     SimpleClientEchoServer.set_args(args)
+     {:ok, 3}
+   end] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.echoState(
+      pid, SimpleClientModels.ActivityState.active)
+    assert response == SimpleClientModels.ActivityState.banned
+    [last_call] = SimpleClientEchoServer.last_call
+    assert last_call == SimpleClientModels.ActivityState.active.value
+  end
+
+  test_with_mock "it should use callbacks to convert things to elixir",
+  :thrift_reconnecting_client,
+  [call: fn(_, _, _) -> {:ok, {:LoudUser, "stinky", "stinkman"}} end] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.getLoudUser(pid)
+    assert response == SimpleClientModels.LoudUser.new(
+      firstName: "STINKY", lastName: "STINKMAN")
+  end
+
+  test_with_mock "it should use callbacks to convert things to erlang",
+  :thrift_reconnecting_client,
+  [call: &SimpleClientEchoServer.call/3] do
+    pid = Process.get(:simple_client_pid)
+    Client.setLoudUser(pid, SimpleClientModels.LoudUser.new(
+      firstName: "STINKY", lastName: "STINKMAN"))
+    {call_name, [user_tuple]} = SimpleClientEchoServer.last_call
+    assert call_name == :setLoudUser
+    assert user_tuple == {:LoudUser, "stinky", "stinkman"}
+  end
+
+  test_with_mock "it should convert enums in lists",
+  :thrift_reconnecting_client,
+  [call: respond_with([3, 2, 1])] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.echoActivityStateList(
+      pid, [SimpleClientModels.ActivityState.active])
+    assert response == [
+      SimpleClientModels.ActivityState.banned,
+      SimpleClientModels.ActivityState.inactive,
+      SimpleClientModels.ActivityState.active]
+   end
+
+  test_with_mock "it should convert enums in maps",
+  :thrift_reconnecting_client,
+  [call: respond_with(:dict.from_list([{"foobar", 3}, {"barfoo", 2}]))] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.getUserStates(pid, ["foobar", "barfoo"])
+    assert response["foobar"] == SimpleClientModels.ActivityState.banned
+    assert response["barfoo"] == SimpleClientModels.ActivityState.inactive
+  end
+
+  test_with_mock "it should convert enums in sets",
+  :thrift_reconnecting_client,
+  [call: respond_with(:sets.from_list([3, 2]))] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.getAllStates(pid)
+    assert response == Enum.into(
+      [SimpleClientModels.ActivityState.banned,
+       SimpleClientModels.ActivityState.inactive],
+      HashSet.new)
+  end
+
+  test_with_mock "it should convert things in response data structures",
+  :thrift_reconnecting_client,
+  [call: respond_with({
+    :ResponseWithMap, :dict.from_list([{1234, user_tuple}])})] do
+
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.getUsers(pid, 1234)
+    user_dict = Enum.into([{1234, user_struct}], HashDict.new)
+    assert response == SimpleClientModels.ResponseWithMap.new(users: user_dict)
+  end
+
+  test_with_mock "it should handle functions defined without argument numbers",
+  :thrift_reconnecting_client,
+  [call: respond_with(1234)] do
+    pid = Process.get(:simple_client_pid)
+    {:ok, response} = Client.functionWithoutNumberedArgs(pid, user_struct, 23)
+    assert response == 1234
+    assert SimpleClientEchoServer.last_call == {
+      :functionWithoutNumberedArgs, [user_tuple, 23]}
+  end
+end


### PR DESCRIPTION
Provides a simple client wrapper, that can specify underlying module.
Return tagged value {:ok, result} | {:error, reason} | {:exception, thrift_exception}