### PR TITLE
Added unknown enum support

### DIFF
--- a/lib/riffed/enumeration.ex
+++ b/lib/riffed/enumeration.ex
@@ -278,6 +278,10 @@ defmodule Riffed.Enumeration do
         defstruct ordinal: nil, value: nil
         unquote_splicing(fns)
 
+        def value(unknown_value) do
+          %unquote(enum_name){value: unknown_value}
+        end
+
         def ordinals do
           unquote(Keyword.keys mapping)
         end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
 %{"certifi": {:hex, :certifi, "0.3.0"},
   "earmark": {:hex, :earmark, "0.1.19"},
   "ex_doc": {:hex, :ex_doc, "0.11.2"},
-  "excoveralls": {:git, "https://github.com/parroty/excoveralls.git", "a0d3d57b7137f3204690e4126a82d48d985a09fb", [tag: "v0.4.3"]},
+  "excoveralls": {:git, "https://github.com/parroty/excoveralls.git", "a0d3d57b7137f3204690e4126a82d48d985a09fb", [tag: "v0.4.5"]},
   "exjsx": {:hex, :exjsx, "3.2.0"},
   "exlager": {:git, "https://github.com/khia/exlager.git", "abb13435a540731b8b9c5f649f4d94f11a27c1f7", []},
   "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "64864ba7fcf40988361340e48680b49a2c2938cf", [tag: "0.1.7"]},

--- a/test/riffed/struct_test.exs
+++ b/test/riffed/struct_test.exs
@@ -27,6 +27,7 @@ defmodule StructTest do
       :day -> 1
       :week -> 2
       :month -> 3
+      # year is intentionally omitted
     end
 
     enumerize_struct NeedsFixup, time: Time
@@ -120,6 +121,18 @@ defmodule StructTest do
   test "Enums in tuples are correctly converted to elixir" do
     actual = {:NeedsFixup, "Foo", 2} |> to_elixir({:struct, {:struct_types, :NeedsFixup}})
     assert Structs.Time.week == actual.time
+  end
+
+  test "Enums with values not defined in elixir get nil ordinals" do
+    actual = {:NeedsFixup, "Foo", 4} |> to_elixir({:struct, {:struct_types, :NeedsFixup}})
+    assert %Structs.Time{value: 4} == actual.time
+  end
+
+  test "nil enums can be turned into erlang" do
+    actual = Structs.NeedsFixup.new(time: Structs.Time.value(4))
+    |> to_erlang({:struct, {:struct_types, :NeedsFixup}})
+
+    assert {:NeedsFixup, _, 4} = actual
   end
 
   test "Enums in structs are properly converted into erlang" do

--- a/thrift/struct.thrift
+++ b/thrift/struct.thrift
@@ -1,7 +1,8 @@
 enum TimePeriod {
   DAY,
   WEEK,
-  MONTH;
+  MONTH,
+  YEAR;
 }
 
 struct Inner {


### PR DESCRIPTION
If you don't map all enums, Riffed will break when converting them to
and from erlang. This change makes it so they're put inside an enum
wrapper with an :unknown ordinal. I'm open to other approaches.

@jparise 