### PR TITLE
Added ability to convert MapSets and Maps

### DIFF
--- a/lib/riffed/callbacks.ex
+++ b/lib/riffed/callbacks.ex
@@ -139,16 +139,29 @@ defmodule Riffed.Callbacks do
       def to_erlang(elixir_dict=%HashDict{}, {:map, {key_type, val_type}}) do
         elixir_dict
         |> Enum.map(
-            fn({k, v}) ->
-              {to_erlang(k, key_type),
-               to_erlang(v, val_type)}
-            end)
+          fn {k, v} ->
+            {to_erlang(k, key_type), to_erlang(v, val_type)}
+          end)
+        |> :dict.from_list
+      end
+
+      def to_erlang(elixir_map=%{}, {:map, {key_type, val_type}}) do
+        elixir_map
+        |> Enum.map(fn {k, v} ->
+          {to_erlang(k, key_type), to_erlang(v, val_type)}
+        end)
         |> :dict.from_list
       end
 
       def to_erlang(elixir_set=%HashSet{}, {:set, item_type}) do
         elixir_set
         |> Enum.map(&(to_erlang(&1, item_type)))
+        |> :sets.from_list
+      end
+
+      def to_erlang(elixir_set=%MapSet{}, {:set, item_type}) do
+        elixir_set
+        |> Enum.map(&to_erlang(&1, item_type))
         |> :sets.from_list
       end
 

--- a/test/riffed/struct_test.exs
+++ b/test/riffed/struct_test.exs
@@ -302,4 +302,17 @@ defmodule StructTest do
     assert struct.values == [[%{1 => "a"}, %{2 => "b"}]]
   end
 
+  test "maps can be serialized to thrift properly" do
+    serialized = Structs.DefaultMap.new |>  Structs.to_erlang(nil)
+
+    assert {:DefaultMap, :dict.from_list([{"cats", 3}, {"dogs", 4}])} == serialized
+  end
+
+  test "mapsets can be serialized to thrift properly" do
+    serialized = Structs.DefaultSetStrings.new(values: Enum.into(["foo", "bar"], MapSet.new))
+    |> Structs.to_erlang(nil)
+
+    assert serialized == {:DefaultSetStrings, :sets.from_list(["foo", "bar"])}
+  end
+
 end


### PR DESCRIPTION
The default converters could not convert maps and mapsets into
thrift. This PR allows users to set mapsets and sets instead of using
deprecated hashdicts and hashsets.

@jparise 