### PR TITLE
Get mock from Hex instead of Github

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,7 @@ defmodule Riffed.Mixfile do
     [
         {:thrift, github: "pinterest/elixir-thrift", tag: "1.0.0", submodules: true},
         {:meck, "~> 0.8.2", only: [:test, :dev]},
-        {:mock, github: "jjh42/mock", only: [:test, :dev]},
+        {:mock, "~> 0.1", only: [:test, :dev]},
         {:exlager, github: "khia/exlager"},
         {:earmark, "~> 0.1", only: :dev},
         {:ex_doc, "~> 0.8", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -9,8 +9,8 @@
   "idna": {:hex, :idna, "1.0.3"},
   "jsx": {:hex, :jsx, "2.6.2"},
   "lager": {:git, "https://github.com/basho/lager.git", "310ed140ab86b95dd9f1f1ed3bf2ca93f841349d", []},
-  "meck": {:hex, :meck, "0.8.3"},
+  "meck": {:hex, :meck, "0.8.4"},
   "mimerl": {:hex, :mimerl, "1.0.2"},
-  "mock": {:git, "https://github.com/jjh42/mock.git", "c2b7dc75bc219124f8b458b62cf9a65616907e04", []},
+  "mock": {:hex, :mock, "0.1.3"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
   "thrift": {:git, "https://github.com/pinterest/elixir-thrift.git", "9c3871cc9568eaf23c701ae11dece7bb5790b8ab", [tag: "1.0.0", submodules: true]}}


### PR DESCRIPTION
Previously we were getting the 'mock' package directly from Github at
jjh42/mock. It has a bug that causes a warning to be displayed when retrieving
it that way. It expects a @version to be available in its mix.exs. That
variable is populated if you retrieve it through Hex. So that's what we do now.