### PR TITLE
Server.start_link accepts server options as arguments

### DIFF
--- a/lib/riffed/client.ex
+++ b/lib/riffed/client.ex
@@ -162,8 +162,10 @@ defmodule Riffed.Client do
         GenServer.start_link(__MODULE__, thrift_client, name: __MODULE__)
       end
 
-      def start_link(host, port) do
-        GenServer.start_link(__MODULE__, {host, port})
+      def start_link(host, port), do: start_link(host, port, [])
+
+      def start_link(host, port, gen_server_opts) do
+        GenServer.start_link(__MODULE__, {host, port}, gen_server_opts)
       end
 
       def handle_call({:disconnect, _args}, _parent, client=%Client{client: thrift_client}) do

--- a/lib/riffed/server.ex
+++ b/lib/riffed/server.ex
@@ -195,11 +195,13 @@ defmodule Riffed.Server do
       unquote(struct_module)
       require Lager
 
-      def start_link do
+      def start_link(cmd_opts \\ []) do
         default_opts = [service: unquote(thrift_module),
                         handler: unquote(env.module),
                         name: unquote(env.module)]
-        opts = Keyword.merge(unquote(server_opts), default_opts)
+        opts = unquote(server_opts)
+               |> Keyword.merge(default_opts)
+               |> Keyword.merge(cmd_opts)
         {:ok, server_pid} = unquote(server).start(opts)
         unquote(after_start).(server_pid, unquote(server_opts))
         {:ok, server_pid}

--- a/test/riffed/server_port_test.exs
+++ b/test/riffed/server_port_test.exs
@@ -1,0 +1,44 @@
+defmodule ServerPortTest do
+  use ExUnit.Case, async: false
+
+  defmodule Server do
+    use Riffed.Server,
+    service: :server_thrift,
+    structs: __MODULE__.Model,
+    auto_build_structs: true,
+    functions: [
+      getLoudUser: &ServerPortTest.Handler.get_loud_user/0,
+    ],
+    server: {:thrift_socket_server,
+             framed: true,
+             max: 10_000,
+             socket_opts: [
+                     recv_timeout: 3000,
+                     keepalive: true]
+            }
+  end
+
+  defmodule Handler do
+    def get_loud_user, do: Server.Model.LoudUser.new
+  end
+
+  defmodule Client do
+    use Riffed.Client,
+    service: :server_thrift,
+    auto_build_structs: true,
+    structs: __MODULE__.Model,
+    client_opts: [framed: true,
+                  retries: 1,
+                 ],
+     import: [:getLoudUser]
+  end
+
+  test "Set server port at runtime" do
+    port = 2113
+    Server.start_link(port: port)
+    Client.start_link("localhost", port, name: Client)
+
+    %Client.Model.LoudUser{} = Client.getLoudUser
+  end
+
+end


### PR DESCRIPTION
We needed this to be able to specify server port in run-time.
