### PR TITLE
Allow multiple clients

### DIFF
--- a/lib/riffed/client.ex
+++ b/lib/riffed/client.ex
@@ -114,8 +114,8 @@ defmodule Riffed.Client do
     |> Keyword.delete(:host)
     |> Keyword.delete(:retries)
 
-    if Module.get_attribute(env.module, :auto_import_structs) do
-      struct_module = quote do
+    struct_module = if Module.get_attribute(env.module, :auto_import_structs) do
+      quote do
         defmodule unquote(struct_module) do
           use Riffed.Struct, unquote(Meta.structs_to_keyword(thrift_metadata))
           unquote_splicing(Riffed.Callbacks.reconstitute(env.module))
@@ -123,7 +123,7 @@ defmodule Riffed.Client do
         end
       end
     else
-      struct_module = quote do
+      quote do
       end
     end
 

--- a/lib/riffed/client.ex
+++ b/lib/riffed/client.ex
@@ -161,6 +161,10 @@ defmodule Riffed.Client do
         GenServer.start_link(__MODULE__, :ok, name: __MODULE__)
       end
 
+      def start_link(thrift_client: thrift_client) do
+        GenServer.start_link(__MODULE__, thrift_client)
+      end
+
       def start_link(thrift_client) do
         GenServer.start_link(__MODULE__, thrift_client, name: __MODULE__)
       end
@@ -240,12 +244,16 @@ defmodule Riffed.Client do
         GenServer.call(__MODULE__, {:disconnect, []})
       end
 
-      def close(pid) do
+      def close(pid) when is_pid(pid) do
         GenServer.call(pid, {:disconnect, []})
       end
 
       def reconnect do
         GenServer.call(__MODULE__, {:reconnect, []})
+      end
+
+      def reconnect(pid) when is_pid(pid) do
+        GenServer.call(pid, {:reconnect, []})
       end
 
       defp to_host(hostname) when is_list(hostname) do

--- a/lib/riffed/macro_helpers.ex
+++ b/lib/riffed/macro_helpers.ex
@@ -15,7 +15,7 @@ defmodule Riffed.MacroHelpers do
     |> Enum.map(&build_arg_cast(function_name, struct_module, &1, overrides, cast_function))
   end
 
-  defp build_arg({index, _type}=arg) do
+  defp build_arg({index, _type}) do
     Macro.var(:"arg_#{abs(index)}", nil)
   end
 

--- a/lib/riffed/server.ex
+++ b/lib/riffed/server.ex
@@ -180,8 +180,8 @@ defmodule Riffed.Server do
 
     structs_keyword = ThriftMeta.Meta.structs_to_keyword(thrift_meta)
 
-    if Module.get_attribute(env.module, :auto_import_structs)  do
-      struct_module = quote do
+    struct_module = if Module.get_attribute(env.module, :auto_import_structs)  do
+      quote do
         defmodule unquote(struct_module) do
           @build_cast_to_erlang true
           use Riffed.Struct, unquote(structs_keyword)
@@ -190,7 +190,7 @@ defmodule Riffed.Server do
         end
       end
     else
-      struct_module = quote do
+      quote do
       end
     end
 

--- a/lib/riffed/struct.ex
+++ b/lib/riffed/struct.ex
@@ -304,9 +304,10 @@ defmodule Riffed.Struct do
     callbacks = Riffed.Callbacks.build(env.module)
     enums = Riffed.Enumeration.build(env.module)
 
-    erlang_casts = []
-    if build_cast_to_erlang do
-      erlang_casts = Riffed.Enumeration.build_cast_return_value_to_erlang(env.module)
+    erlang_casts = if build_cast_to_erlang do
+      Riffed.Enumeration.build_cast_return_value_to_erlang(env.module)
+    else
+      []
     end
 
     quote do

--- a/test/riffed/multi_client_test.exs
+++ b/test/riffed/multi_client_test.exs
@@ -1,0 +1,30 @@
+defmodule MultiClientTest do
+  use ExUnit.Case
+
+  defmodule ClientModels do
+    use Riffed.Struct, account_types: [:Account, :Preferences]
+  end
+
+  defmodule AccountClient do
+    use Riffed.Client, structs: ClientModels,
+    client_opts: [host: "localhost",
+                  port: 3112,
+                  framed: true,
+                  retries: 1,
+                  socket_opts: [
+                          recv_timeout: 3000,
+                          keepalive: true]
+                 ],
+    service: :shared_service_thrift,
+    import: [:getAccount]
+  end
+
+  test "allow multiple clients" do
+    {:ok, echo} = EchoServer.start_link
+
+    {:ok, pid1} = AccountClient.start_link(thrift_client: echo)
+    {:ok, pid2} = AccountClient.start_link(thrift_client: echo)
+
+    refute pid1 == pid2
+  end
+end


### PR DESCRIPTION
I've adapted the `Client` to be able to start multiple `GenServer`s. I didn't want to change the behavior of any of the other `start_link` functions, so there's a new function signature...

``` elixir
{:ok, pid} = SomeClient.start_link(thrift_client: thrift_client)
```

Also included is a test of this behavior, and fixes to a few Elixir 1.3 compiler warnings.

Thanks!
