### PR TITLE
Added bang functions to client

### DIFF
--- a/test/riffed/shared_client_test.exs
+++ b/test/riffed/shared_client_test.exs
@@ -75,12 +75,12 @@ defmodule SharedClientTest do
 
   test_with_mock "it should get preferences", :thrift_client,
   [call: respond_with({:Preferences, 1234, true})] do
-    assert Factory.preferences(1234) == PrefClient.getPreferences(1234)
+    assert Factory.preferences(1234) == PrefClient.getPreferences!(1234)
   end
 
   test_with_mock "it should get the account", :thrift_client,
   [call: respond_with({:Account, 1234, {:Preferences, 1234, true},
                        "foo@bar.com", 12345, 67890})] do
-    assert Factory.account(1234) == AccountClient.getAccount(1234)
+    assert Factory.account(1234) == AccountClient.getAccount!(1234)
   end
 end


### PR DESCRIPTION
The Elixir idiom is to have a function that ends with an exclamation
point throw an exception, and an unadorned function return `{:ok,
response}` or `{:error, reason}`. This PR changes Riffed to respoect
that idiom. It is a breaking change, and will break all clients
upgrading from any version of elixometer < 1.5

Addresses https://github.com/pinterest/riffed/issues/38
@jparise @fire 