### PR TITLE
Make Elixir 1.2 the lowest supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
-  - 1.3.2
+  - 1.2.6
+  - 1.3.4
 otp_release:
   - 19.0
 sudo: required

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Riffed.Mixfile do
     [app: :riffed,
      name: "Riffed",
      version: "1.0.0",
-     elixir: "~> 1.0",
+     elixir: "~> 1.2",
      deps: deps,
      compilers: compilers(Mix.env),
      erlc_paths: ["src", "ext/thrift/lib/erl/src"],


### PR DESCRIPTION
This lets us reliably use more advanced language features. It also
makes us compatible with the latest version of the [thrift](https://hex.pm/packages/thrift) package.