### PR TITLE
Upgrade to version 1.3 of the :thrift package

### DIFF
--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -6,7 +6,7 @@ We'll assume you already have a Mix project to work with called `rift_tutorial`.
 
 ```elixir
 def deps do
-  [{:riffed, github: "pinterest/riffed", tag: "1.0.0", submodules: true}]
+  [{:riffed, github: "pinterest/riffed"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Riffed.Mixfile do
 
   defp deps do
     [
-        {:thrift, github: "pinterest/elixir-thrift", tag: "1.0.0", submodules: true},
+        {:thrift, "~> 1.3"},
         {:meck, "~> 0.8.2", only: [:test, :dev]},
         {:mock, github: "jjh42/mock", only: [:test, :dev]},
         {:exlager, github: "khia/exlager"},

--- a/mix.lock
+++ b/mix.lock
@@ -9,10 +9,10 @@
   "idna": {:hex, :idna, "1.2.0", "ac62ee99da068f43c50dc69acf700e03a62a348360126260e87f2b54eced86b2", [:rebar3], []},
   "jsx": {:hex, :jsx, "2.6.2", "213721e058da0587a4bce3cc8a00ff6684ced229c8f9223245c6ff2c88fbaa5a", [:mix, :rebar], []},
   "lager": {:git, "https://github.com/basho/lager.git", "8187757388c9adc915379caaab36a2f2ca26e944", []},
-  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
+  "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:make, :rebar], []},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], []},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], []},
   "mock": {:git, "https://github.com/jjh42/mock.git", "7f2251f781f646a08bb65c85c215f107c9627435", []},
-  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:rebar, :make], []},
+  "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.0", "edee20847c42e379bf91261db474ffbe373f8acb56e9079acb6038d4e0bf414f", [:make, :rebar], []},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5", "2e73e068cd6393526f9fa6d399353d7c9477d6886ba005f323b592d389fb47be", [:make], []},
-  "thrift": {:git, "https://github.com/pinterest/elixir-thrift.git", "9c3871cc9568eaf23c701ae11dece7bb5790b8ab", [tag: "1.0.0", submodules: true]}}
+  "thrift": {:hex, :thrift, "1.3.0", "d12c2689ba4dcfa33ecd2c99d783cc205fa2a47176c8c972a7e0e5b137023ffd", [:mix], []}}


### PR DESCRIPTION
This includes a number of small improvements in addition to better
Elixir 1.3 compatibility.

This also move us to the Hex-based version of the package. This is a
much smaller download because it doesn't include the entire Apache
Thrift distribution as a nested submodule.