### PR TITLE
Update the tutorial's riffed dependency

### DIFF
--- a/examples/tutorial/mix.exs
+++ b/examples/tutorial/mix.exs
@@ -31,7 +31,7 @@ defmodule RiffedTutorial.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:riffed, github: "pinterest/riffed", tag: "1.0.0", submodules: true}
+      {:riffed, github: "pinterest/riffed"}
     ]
   end
 end

--- a/examples/tutorial/mix.lock
+++ b/examples/tutorial/mix.lock
@@ -3,5 +3,5 @@
   "lager": {:git, "https://github.com/basho/lager.git", "b2cb2735713e3021e0761623ff595d53a545438e", []},
   "meck": {:hex, :meck, "0.8.4"},
   "mock": {:git, "https://github.com/jjh42/mock.git", "cac37bc0567d8f61e542dbe29944844261888b3a", []},
-  "riffed": {:git, "https://github.com/pinterest/riffed.git", "ca083d52d4ecfad822432da3925f644bc748f260", [tag: "1.0.0", submodules: true]},
-  "thrift": {:git, "https://github.com/pinterest/elixir-thrift.git", "9c3871cc9568eaf23c701ae11dece7bb5790b8ab", [tag: "1.0.0", submodules: true]}}
+  "riffed": {:git, "https://github.com/pinterest/riffed.git", "bca4a4e4e1b4327007a6850787709be59f06a48e", []},
+  "thrift": {:hex, :thrift, "1.3.0", "d12c2689ba4dcfa33ecd2c99d783cc205fa2a47176c8c972a7e0e5b137023ffd", [:mix], []}}


### PR DESCRIPTION
We no longer need to fetch submodules.