### PR TITLE
Use Logger.warn/1 to report connection timeouts

### DIFF
--- a/lib/riffed/server.ex
+++ b/lib/riffed/server.ex
@@ -137,7 +137,7 @@ defmodule Riffed.Server do
   defp build_error_handler(nil) do
     quote do
       def handle_error(_, :timeout) do
-        Logger.notice("Connection to client timed out.")
+        Logger.warn("Connection to client timed out.")
         {:ok, :timeout}
       end
 


### PR DESCRIPTION
Logger.notice/1 doesn't exist and is a remnant of the Lager -> Logger
conversion.

Fixes #49 