### PR TITLE
Resolve a compiler warning with quoted atom in mix.ex

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Riffed.Mixfile do
      thrift_files: Mix.Utils.extract_files(["thrift"], [:thrift]),
      docs: [output: "doc/generated"],
      test_coverage: [tool: ExCoveralls],
-     preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test],
+     preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test],
 
      # Hex
      description: description(),


### PR DESCRIPTION
Example of the warning is here:

```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted. Similar to atoms, keywords made exclusively of Unicode letters, numbers, underscore, and @ do not require quotes
    <unimportant projdir>/deps/riffed/mix.exs:18
Resolving Hex dependencies...
Dependency resolution completed:
New:
thrift 1.3.2                                                                                                                                                                                                    * Getting thrift (Hex package)      
```

This PR takes the recommended action.